### PR TITLE
created SendToRecipient component, 'create contract' button not yet working

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "prime-solo-project",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:5000",
+  "proxy": "http://localhost:5007",
   "engines": {
     "node": "16.x"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -30,7 +30,7 @@ app.use('/api/contract', contractRouter);
 app.use(express.static('build'));
 
 // App Set //
-const PORT = process.env.PORT || 5000;
+const PORT = process.env.PORT || 5007;
 
 /** Listen * */
 app.listen(PORT, () => {

--- a/src/components/CreateContract/CreateContractDetails.jsx
+++ b/src/components/CreateContract/CreateContractDetails.jsx
@@ -114,8 +114,25 @@ const CreateContractDetails = () => {
             </Grid>
           </Box>
           <br />
-          <Button variant="contained" onClick={() => history.push('/create-contract-review')}>Review Contract</Button>  
+          {/* <Button variant="contained" onClick={() => history.push('/create-contract-review')}>Review Contract</Button>   */}
         </Grid>
+        <Box sx={{display: 'flex', justifyContent: 'center'}}>
+            <Button 
+              variant="contained"
+              onClick={(event) => history.push('/party-type')}
+              sx={{marginRight: 1, width: 200}}
+            >
+              Edit Party Type
+            </Button>
+            {/* Preview button here */}
+            <Button 
+              variant="contained"
+              onClick={(event) => history.push('/create-contract-review')}
+              sx={{marginLeft: 1, width: 200}}
+            >
+              Review Contract
+            </Button>
+          </Box>
     </div>
   );
 }

--- a/src/components/CreateContract/CreateContractDetails.jsx
+++ b/src/components/CreateContract/CreateContractDetails.jsx
@@ -41,6 +41,8 @@ const CreateContractDetails = () => {
     <div>
         <Typography variant="h3" sx={{textAlign: "center"}}>Create New Contract</Typography>
         <br />
+        <Typography variant="h6" sx={{textAlign: "center"}}>You are the {newContractDetails.firstPartyType}.</Typography>
+        <br />
         <Grid
           container
           spacing={2}

--- a/src/components/CreateContract/CreateContractReview.jsx
+++ b/src/components/CreateContract/CreateContractReview.jsx
@@ -73,7 +73,7 @@ const CreateContractReview = () => {
                 <TableRow>
                   <TableCell sx={{width: 150}} align="left"><Typography>Images:</Typography></TableCell>
                   {/* once image upload is enabled, the img src will be the uploaded image file */}
-                  <TableCell align="left"><img src="https://images.unsplash.com/photo-1531104985437-603d6490e6d4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1678&q=80" width="200"/></TableCell>
+                  <TableCell align="left"><img src="https://images.unsplash.com/photo-1531104985437-603d6490e6d4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1678&q=80" alt="stereo" width="200"/></TableCell>
                 </TableRow>
               </TableBody>
             </Table>

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -31,6 +31,7 @@ const SendToRecipient = () => {
             sx={{width: 300, marginLeft: 2}}
             helperText="Enter Recipient's Email"
             label="example@gmail.com"
+            value={newContractDetails.secondPartyEmail}
           />
         </Box>
         <br />
@@ -55,8 +56,10 @@ const SendToRecipient = () => {
             <Typography sx={{textAlign: 'center'}}>The above property will be transferred on: {formattedPickupDate}</Typography>
             <Typography sx={{textAlign: 'center'}}>The seller and buyer will meet in {newContractDetails.pickupLocation} to transfer the above property.</Typography>
             <br />
-            <Typography sx={{textAlign: 'center'}}>{newContractDetails.firstPartyType} Signature: {newContractDetails.firstPartySignature}</Typography>
-            <Typography sx={{textAlign: 'center'}}>{newContractDetails.secondPartyType} Signature: {newContractDetails.secondPartySignature}</Typography>
+            <Box sx={{ p: 2, border: '1px solid grey' }}>
+              <Typography sx={{textAlign: 'center'}}>{newContractDetails.firstPartyType} Signature: {newContractDetails.firstPartySignature}</Typography>
+              <Typography sx={{textAlign: 'center'}}>{newContractDetails.secondPartyType} Signature: {newContractDetails.secondPartySignature}</Typography>
+            </Box>
           </Paper>
       </Container>
     </div>

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -23,15 +23,23 @@ const SendToRecipient = () => {
 
   return (
     <div>
+      
         <Box sx={{display: 'flex', justifyContent: 'center'}}>
-          <Typography variant="h3" sx={{textAlign: "center"}}>Send to Recipient:</Typography>
+          <Typography variant="h3">Send to Recipient:</Typography>
           <TextField
             sx={{width: 300, marginLeft: 2}}
             helperText="Enter Recipient's Email"
             label="example@gmail.com"
           />
         </Box>
-
+        <br />
+        <br />
+        <Container sx={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
+          <Paper elevation={10} variant="outlined" sx={{width: 700, padding: 2, display: 'flex', flexDirection: 'column'}}>
+            <Typography sx={{textAlign: 'center'}}>{newContractDetails.contractTitle} Agreement</Typography>
+            <Typography sx={{textAlign: 'center'}}></Typography>
+          </Paper>
+      </Container>
     </div>
   );
 

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -1,10 +1,37 @@
 import { useState } from 'react';
+import {useHistory} from 'react-router-dom';
+import {useDispatch, useSelector} from 'react-redux';
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
 
 const SendToRecipient = () => {
 
+  const history = useHistory();
+  const newContractDetails = useSelector(store => store.contract.newContractDetails);
+
+  // date formatting for pickup date
+  const pickupDate = new Date(newContractDetails.pickupDate);
+  const formattedPickupDate = pickupDate.toLocaleDateString('en-US', { year: '2-digit', month: '2-digit', day: '2-digit' });
+
+  // date formatting for contract deadline
+  const contractDeadline = new Date(newContractDetails.contractDeadline);
+  const formattedContractDeadline = contractDeadline.toLocaleDateString('en-US', { year: '2-digit', month: '2-digit', day: '2-digit' });
+
   return (
     <div>
-        <h1>SendToRecipient</h1>
+        <Box sx={{display: 'flex', justifyContent: 'center'}}>
+          <Typography variant="h3" sx={{textAlign: "center"}}>Send to Recipient:</Typography>
+          <TextField
+            sx={{width: 300, marginLeft: 2}}
+            helperText="Enter Recipient's Email"
+            label="example@gmail.com"
+          />
+        </Box>
+
     </div>
   );
 

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -77,6 +77,23 @@ const SendToRecipient = () => {
             </Box>
           </Paper>
       </Container>
+      <br />
+      <Box sx={{display: 'flex', justifyContent: 'center'}}>
+            <Button 
+              variant="contained"
+              onClick={() => history.push('/create-contract-review')}
+              sx={{marginRight: 1, width: 200}}
+            >
+              Review Contract Details
+            </Button>
+            <Button 
+              variant="contained"
+              // add onClick function that dispatches to new contract POST saga
+              sx={{marginLeft: 1, width: 200}}
+            >
+              Create Contract and Send to Recipient
+            </Button>
+          </Box>
     </div>
   );
 

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -11,6 +11,7 @@ import TextField from '@mui/material/TextField';
 const SendToRecipient = () => {
 
   const history = useHistory();
+  const dispatch = useDispatch();
   const newContractDetails = useSelector(store => store.contract.newContractDetails);
   const user = useSelector((store) => store.user);
 
@@ -22,6 +23,12 @@ const SendToRecipient = () => {
   const contractDeadline = new Date(newContractDetails.contractDeadline);
   const formattedContractDeadline = contractDeadline.toLocaleDateString('en-US', { year: '2-digit', month: '2-digit', day: '2-digit' });
 
+  // onChange in a textfield, the key value is set in the newContractDetails reducer
+  const handleChangeFor = (key) => (event) => {
+    console.log('in handleChangeFor');
+    dispatch({ type: 'SET_NEW_CONTRACT_DETAILS', payload: {...newContractDetails, [key]: event.target.value}});
+  }
+
   return (
     <div>
       
@@ -32,6 +39,7 @@ const SendToRecipient = () => {
             helperText="Enter Recipient's Email"
             label="example@gmail.com"
             value={newContractDetails.secondPartyEmail}
+            onChange={handleChangeFor('secondPartyEmail')}
           />
         </Box>
         <br />

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -29,6 +29,15 @@ const SendToRecipient = () => {
     dispatch({ type: 'SET_NEW_CONTRACT_DETAILS', payload: {...newContractDetails, [key]: event.target.value}});
   }
 
+  // dispatching newContractDetails and the SendGrid email function to the addNewContract saga
+  const submitNewContract = () => {
+    console.log('in submitNewContract', newContractDetails);
+    // the SendGrid email function will be passed in the dispatch after the payload
+    // dispatch({type: 'ADD_NEW_CONTRACT', payload: newContractDetails});
+  }
+
+  // SendGrid email function that fires from the addNewContract saga
+
   return (
     <div>
       
@@ -45,7 +54,7 @@ const SendToRecipient = () => {
         <br />
         <br />
         <Container sx={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-          <Paper elevation={10} variant="outlined" sx={{width: 700, padding: 2, display: 'flex', flexDirection: 'column'}}>
+          <Paper elevation={10} sx={{width: 700, padding: 2, display: 'flex', flexDirection: 'column'}}>
             <Typography variant="h6" sx={{textAlign: 'center'}}>{newContractDetails.contractTitle} Agreement</Typography>
             {/* user.username will be changed to user.legalName when registration/login is working */}
             <Typography sx={{textAlign: 'center'}}>{user.username} (the "{newContractDetails.firstPartyType}") does hereby sell, assign, and transfer to</Typography>
@@ -89,6 +98,7 @@ const SendToRecipient = () => {
             <Button 
               variant="contained"
               // add onClick function that dispatches to new contract POST saga
+              onClick={submitNewContract}
               sx={{marginLeft: 1, width: 200}}
             >
               Create Contract and Send to Recipient

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -12,6 +12,7 @@ const SendToRecipient = () => {
 
   const history = useHistory();
   const newContractDetails = useSelector(store => store.contract.newContractDetails);
+  const user = useSelector((store) => store.user);
 
   // date formatting for pickup date
   const pickupDate = new Date(newContractDetails.pickupDate);
@@ -36,8 +37,26 @@ const SendToRecipient = () => {
         <br />
         <Container sx={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
           <Paper elevation={10} variant="outlined" sx={{width: 700, padding: 2, display: 'flex', flexDirection: 'column'}}>
-            <Typography sx={{textAlign: 'center'}}>{newContractDetails.contractTitle} Agreement</Typography>
-            <Typography sx={{textAlign: 'center'}}></Typography>
+            <Typography variant="h6" sx={{textAlign: 'center'}}>{newContractDetails.contractTitle} Agreement</Typography>
+            {/* user.username will be changed to user.legalName when registration/login is working */}
+            <Typography sx={{textAlign: 'center'}}>{user.username} (the "{newContractDetails.firstPartyType}") does hereby sell, assign, and transfer to</Typography>
+            <Typography sx={{textAlign: 'center'}}>*recipient legal name* (the "{newContractDetails.secondPartyType}") the following property:</Typography>
+            <br />
+            <Typography sx={{textAlign: 'center'}}>{newContractDetails.itemName}: {newContractDetails.itemDescription}</Typography>
+            <br />
+            <Typography sx={{textAlign: 'center'}}>for a TOTAL AMOUNT OF ${newContractDetails.itemPrice}</Typography>
+            <br />
+            <Typography sx={{textAlign: 'center'}}>The seller warrants that they are the legal owner of the property and that it is being transferred to the buyer free and clear of any liens or encumbrances.</Typography>
+            <Typography sx={{textAlign: 'center'}}>The above property is sold on an "AS IS" basis. The seller makes no warranites, express or implied (except as specially stated in this document).</Typography>
+            <br />
+            <Typography sx={{textAlign: 'center'}}>Notes regarding the above property:</Typography>
+            <Typography sx={{textAlign: 'center'}}>{newContractDetails.contractNotes}</Typography>
+            <br />
+            <Typography sx={{textAlign: 'center'}}>The above property will be transferred on: {formattedPickupDate}</Typography>
+            <Typography sx={{textAlign: 'center'}}>The seller and buyer will meet in {newContractDetails.pickupLocation} to transfer the above property.</Typography>
+            <br />
+            <Typography sx={{textAlign: 'center'}}>{newContractDetails.firstPartyType} Signature: {newContractDetails.firstPartySignature}</Typography>
+            <Typography sx={{textAlign: 'center'}}>{newContractDetails.secondPartyType} Signature: {newContractDetails.secondPartySignature}</Typography>
           </Paper>
       </Container>
     </div>

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -61,6 +61,13 @@ const SendToRecipient = () => {
             <Typography sx={{textAlign: 'center'}}>Notes regarding the above property:</Typography>
             <Typography sx={{textAlign: 'center'}}>{newContractDetails.contractNotes}</Typography>
             <br />
+            <Typography sx={{textAlign: 'center'}}>"AS IS" images of the above property provided by the seller:</Typography>
+            <br />
+            <Box sx={{display: 'flex', justifyContent: 'center', p: 2, border: '1px solid grey' }}>
+              {/* images will be the user-uploaded images once that functionality is implemented */}
+              <img src="https://images.unsplash.com/photo-1531104985437-603d6490e6d4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1678&q=80" alt= "stereo" width="200"/>
+            </Box>
+            <br />
             <Typography sx={{textAlign: 'center'}}>The above property will be transferred on: {formattedPickupDate}</Typography>
             <Typography sx={{textAlign: 'center'}}>The seller and buyer will meet in {newContractDetails.pickupLocation} to transfer the above property.</Typography>
             <br />

--- a/src/redux/reducers/contract.reducer.js
+++ b/src/redux/reducers/contract.reducer.js
@@ -2,7 +2,9 @@ import { combineReducers } from 'redux';
 
 const defaultNewContract = {
     firstPartyType: '',
+    firstPartyEmail: '',
     secondPartyType: '',
+    secondPartyEmail: '',
     contractTitle: '',
     itemName: '',
     itemDescription: '',


### PR DESCRIPTION
I created the SendToRecipient component. I found a simple and short purchase agreement template online that I referenced to build a more realistic contract template. The newContractDetails reducer property values are referenced throughout the contract template. 

When the user types in the recipient's email, the secondPartyEmail value in the newContractDetails reducer is set. 

I added firstPartyEmail and secondPartyEmail to the default newContractDetails in contract.reducer.js.

I also added a back button in CreateContractDetails to bring the user back to PartyType, if needed. I also added a line at the top of CreateContractDetails telling the user which party type they chose for themselves. 