### PR TITLE
Built ContractRecipientAccess component, added URL param, revised App.jsx route and GET by contract key route

### DIFF
--- a/server/routes/recipient.router.js
+++ b/server/routes/recipient.router.js
@@ -6,10 +6,14 @@ const router = express.Router();
 router.get('/:id', (req, res) => {
     console.log('in /api/recipient GET contract by contract key');
     console.log('contract key is:', req.params.id);
-    const queryText =   `SELECT * FROM "contract"
+    const queryText = `SELECT * FROM "contract"
                         WHERE "contract"."contract_key" = $1;`;
     pool.query(queryText, [req.params.id]).then(result => {
-        res.send(result.rows[0]);
+        if (result.rows.length > 0) {
+            res.send(result.rows[0]); //single contract object
+        } else {
+            res.send({});
+        }
     }).catch(error => {
         console.log('Error in /api/recipient GET contract by contract key:', error);
         res.sendStatus(500);

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -219,7 +219,7 @@ function App() {
             </Route>
 
             <Route
-              exact path="/recipient-view"
+              exact path="/recipient-view/:searchContractKey"
             >
               <RecipientView />
             </Route>

--- a/src/components/ContractRecipientAccess/ContractRecipientAccess.jsx
+++ b/src/components/ContractRecipientAccess/ContractRecipientAccess.jsx
@@ -15,6 +15,19 @@ const ContractRecipientAccess = () => {
   // local state for changeable values of contract key being searched
   const [searchContractKey, setSearchContractKey] = useState('');
 
+  // dispatches 'FETCH_RECIPIENT_CONTRACT'. payload is contract key and function goToRecipientView 
+  const retrieveContractByKey = (event) => {
+    event.preventDefault();
+    console.log('in retrieveContractByKey. Contract key to search is:', searchContractKey);
+    dispatch({ type: 'FETCH_RECIPIENT_CONTRACT', payload: searchContractKey, goToRecipientView });
+  }
+
+  // after successful 'FETCH_RECIPIENT_CONTRACT', navigates user to recipient view
+  const goToRecipientView = () => {
+    console.log('in goToRecipientView');
+    history.push('/recipient-view');
+  }
+
   return (
     <div>
       <Typography variant="h3" sx={{ textAlign: "center" }}>Access Contract</Typography>
@@ -22,7 +35,7 @@ const ContractRecipientAccess = () => {
       <br />
       <Grid container spacing={2} direction="column" alignItems="center" justifyContent="center">
         <Grid item>
-          <form>
+          <form onSubmit={retrieveContractByKey}>
             <TextField
               required
               fullWidth

--- a/src/components/ContractRecipientAccess/ContractRecipientAccess.jsx
+++ b/src/components/ContractRecipientAccess/ContractRecipientAccess.jsx
@@ -8,24 +8,15 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
 const ContractRecipientAccess = () => {
-
-  const dispatch = useDispatch();
   const history = useHistory();
 
   // local state for changeable values of contract key being searched
   const [searchContractKey, setSearchContractKey] = useState('');
 
-  // dispatches 'FETCH_RECIPIENT_CONTRACT'. payload is contract key and function goToRecipientView 
   const retrieveContractByKey = (event) => {
     event.preventDefault();
     console.log('in retrieveContractByKey. Contract key to search is:', searchContractKey);
-    dispatch({ type: 'FETCH_RECIPIENT_CONTRACT', payload: searchContractKey, goToRecipientView });
-  }
-
-  // after successful 'FETCH_RECIPIENT_CONTRACT', navigates user to recipient view
-  const goToRecipientView = () => {
-    console.log('in goToRecipientView');
-    history.push('/recipient-view');
+    history.push(`/recipient-view/${searchContractKey}`);
   }
 
   return (

--- a/src/components/ContractRecipientAccess/ContractRecipientAccess.jsx
+++ b/src/components/ContractRecipientAccess/ContractRecipientAccess.jsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
 const ContractRecipientAccess = () => {
@@ -14,6 +18,26 @@ const ContractRecipientAccess = () => {
   return (
     <div>
       <Typography variant="h3" sx={{ textAlign: "center" }}>Access Contract</Typography>
+      <br />
+      <br />
+      <Grid container spacing={2} direction="column" alignItems="center" justifyContent="center">
+        <Grid item>
+          <form>
+            <TextField
+              required
+              fullWidth
+              label="Contract Key"
+              size="small"
+              helperText="Enter the contract key provided in the TradeOut email."
+              value={searchContractKey}
+              onChange={(event) => setSearchContractKey(event.target.value)}
+            />
+            <Box textAlign="center" sx={{ mt: 4 }}>
+              <Button type="submit" variant="contained">View Contract</Button>
+            </Box>
+          </form>
+        </Grid>
+      </Grid>
     </div>
   );
 }

--- a/src/components/ContractRecipientAccess/ContractRecipientAccess.jsx
+++ b/src/components/ContractRecipientAccess/ContractRecipientAccess.jsx
@@ -1,18 +1,19 @@
-import React, { useState } from 'react';
-import {useSelector} from 'react-redux';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import Typography from '@mui/material/Typography';
 
-// Basic functional component structure for React with default state
-// value setup. When making a new component be sure to replace the
-// component name TemplateFunction with the name for the new component.
-function ContractRecipientAccess(props) {
-  // Using hooks we're creating local state for a "heading" variable with
-  // a default value of 'Functional Component'
-  const store = useSelector((store) => store);
-  const [heading, setHeading] = useState('Contract Recipient Access');
+const ContractRecipientAccess = () => {
+
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  // local state for changeable values of contract key being searched
+  const [searchContractKey, setSearchContractKey] = useState('');
 
   return (
     <div>
-      <h2>{heading}</h2>
+      <Typography variant="h3" sx={{ textAlign: "center" }}>Access Contract</Typography>
     </div>
   );
 }

--- a/src/components/RecipientView/RecipientView.jsx
+++ b/src/components/RecipientView/RecipientView.jsx
@@ -1,9 +1,20 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
 function RecipientView() {
+  const dispatch = useDispatch();
+  // client-side URL param, corresponds to route exact path in App.jsx
+  const { searchContractKey } = useParams();
+
+  // dispatches FETCH_RECIPIENT_CONTRACT whenever searchContractKey changes
+  useEffect(() => {
+    dispatch({ type: 'FETCH_RECIPIENT_CONTRACT', payload: searchContractKey });
+  }, [searchContractKey]);
+
   return (
     <div>
-        <h1>RecipientView</h1>
+      <h1>RecipientView</h1>
     </div>
   );
 }


### PR DESCRIPTION
Built out ContractRecipientAccess component with validation to check Contract Key input field isn't empty. User inputs contract key from TradeOut email and clicks 'View Contract'.  searchContractKey is set using local state and passed as a URL param. Updated route in App.jsx so that user is navigated to '/recipient-view/:searchContractKey'. 

In RecipientView component, added useEffect to dispatch 'FETCH_RECIPIENT_CONTRACT' with payload of URL param searchContractKey whenever searchContractKey changes. 

Updated server router GET by contract key in recipient.router.js to return an empty object when no contract is found by contract key. 