### PR TITLE
updates to create new contract components

### DIFF
--- a/src/components/CreateContract/CreateContractDetails.jsx
+++ b/src/components/CreateContract/CreateContractDetails.jsx
@@ -37,6 +37,7 @@ const CreateContractDetails = () => {
     }
   }
 
+  // validating that the required fields have a value
   const validateForm = () => {
     console.log('in validateForm');
     if (!newContractDetails.contractTitle || !newContractDetails.itemName || !newContractDetails.itemDescription || !newContractDetails.itemPrice || !newContractDetails.pickupLocation || !newContractDetails.pickupDate || !newContractDetails.firstPartySignature) {
@@ -47,9 +48,27 @@ const CreateContractDetails = () => {
     }
   }
 
+  // filling the form textfields for demo purposes
+  const autofillForm = () => {
+    console.log('in autofillForm');
+    dispatch({type: 'SET_NEW_CONTRACT_DETAILS', payload: {
+      ...newContractDetails, 
+      contractTitle: 'Car Purchase',
+      itemName: 'Honda Accord',
+      itemDescription: '2008, blue',
+      itemPrice: 1500,
+      pickupLocation: 'St. Paul, MN',
+      pickupDate: '12/15/2022',
+      contractDeadline: '12/13/2022',
+      contractNotes: 'payment in cash, new tires as of October 2022, no know mechanical issues',
+      firstPartySignature: 'Eliot Winter'
+    }});
+  }
+
   return (
     <div>
         <Typography variant="h3" sx={{textAlign: "center"}}>Create New Contract</Typography>
+        <div onClick={autofillForm}><h5>magic button</h5></div>
         <br />
         <Typography variant="h6" sx={{textAlign: "center"}}>You are the {newContractDetails.firstPartyType}.</Typography>
         <br />

--- a/src/components/CreateContract/CreateContractDetails.jsx
+++ b/src/components/CreateContract/CreateContractDetails.jsx
@@ -68,7 +68,7 @@ const CreateContractDetails = () => {
   return (
     <div>
         <Typography variant="h3" sx={{textAlign: "center"}}>Create New Contract</Typography>
-        <div onClick={autofillForm}><h5>magic button</h5></div>
+        <div style={{width: 100}} onClick={autofillForm}><h5>magic button</h5></div>
         <br />
         <Typography variant="h6" sx={{textAlign: "center"}}>You are the {newContractDetails.firstPartyType}.</Typography>
         <br />

--- a/src/components/CreateContract/CreateContractDetails.jsx
+++ b/src/components/CreateContract/CreateContractDetails.jsx
@@ -35,9 +35,17 @@ const CreateContractDetails = () => {
     } else {
         alert('Contract notes cannot be more than 600 characters.');
     }
-}
+  }
 
-
+  const validateForm = () => {
+    console.log('in validateForm');
+    if (!newContractDetails.contractTitle || !newContractDetails.itemName || !newContractDetails.itemDescription || !newContractDetails.itemPrice || !newContractDetails.pickupLocation || !newContractDetails.pickupDate || !newContractDetails.firstPartySignature) {
+      alert('Please completed all required fields (those with a *).');
+      return;
+    } else {
+      history.push('/create-contract-review');
+    }
+  }
 
   return (
     <div>
@@ -53,17 +61,18 @@ const CreateContractDetails = () => {
           justifyContent="center"
         >
           <Grid item sx={{width: 400}}>
-            <TextField fullWidth label="Contract Title" size="small" value={newContractDetails.contractTitle} onChange={handleChangeFor('contractTitle')}/>
+            <TextField required fullWidth label="Contract Title" size="small" value={newContractDetails.contractTitle} onChange={handleChangeFor('contractTitle')}/>
           </Grid>
           <Grid item sx={{width: 400}}>
-            <TextField fullWidth label="Item Name" size="small" value={newContractDetails.itemName} onChange={handleChangeFor('itemName')}/>
+            <TextField required fullWidth label="Item Name" size="small" value={newContractDetails.itemName} onChange={handleChangeFor('itemName')}/>
           </Grid>
           <Grid item sx={{width: 400}}>
-            <TextField fullWidth label="Item Description" size="small" value={newContractDetails.itemDescription} onChange={handleChangeFor('itemDescription')}/>
+            <TextField required fullWidth label="Item Description" size="small" value={newContractDetails.itemDescription} onChange={handleChangeFor('itemDescription')}/>
           </Grid>
           <Grid item sx={{width: 400}}>
             <TextField
               fullWidth 
+              required
               label="Item Price" 
               size="small"
               value={newContractDetails.itemPrice}
@@ -74,11 +83,12 @@ const CreateContractDetails = () => {
               />
           </Grid>
           <Grid item sx={{width: 400}}>
-            <TextField fullWidth label="Pickup Location" size="small" value={newContractDetails.pickupLocation} onChange={handleChangeFor('pickupLocation')}/>
+            <TextField required fullWidth label="Pickup Location" size="small" value={newContractDetails.pickupLocation} onChange={handleChangeFor('pickupLocation')}/>
           </Grid>
           <Grid item sx={{width: 400}}>
             <DatePicker 
               value={newContractDetails.pickupDate}
+              required
               onChange={(newValue) => handleDate('pickupDate', newValue)}
               label="Pickup Date"
               renderInput={(params) => <TextField fullWidth size="small" {...params} />}
@@ -91,7 +101,7 @@ const CreateContractDetails = () => {
               value={newContractDetails.contractDeadline}
               onChange={(newValue) => handleDate('contractDeadline', newValue)}
               label="Contract Deadline"
-              renderInput={(params) => <TextField fullWidth size="small" {...params} />}
+              renderInput={(params) => <TextField {...params} fullWidth size="small" />}
               openTo="day"
               views={['year', 'month', 'day']}
             />
@@ -109,7 +119,7 @@ const CreateContractDetails = () => {
           </Grid>
           <br />
           <Grid item sx={{width: 400}}>
-            <TextField fullWidth label="Your Signature" size="small" value={newContractDetails.firstPartySignature} onChange={handleChangeFor('firstPartySignature')}/>
+            <TextField required fullWidth label="Your Signature" size="small" value={newContractDetails.firstPartySignature} onChange={handleChangeFor('firstPartySignature')}/>
           </Grid>
           <br />
           <Box>
@@ -131,7 +141,7 @@ const CreateContractDetails = () => {
             {/* Preview button here */}
             <Button 
               variant="contained"
-              onClick={(event) => history.push('/create-contract-review')}
+              onClick={validateForm}
               sx={{marginLeft: 1, width: 200}}
             >
               Review Contract

--- a/src/components/CreateContract/PartyType.jsx
+++ b/src/components/CreateContract/PartyType.jsx
@@ -34,6 +34,10 @@ const PartyType = () => {
   // secondPartyType is set in newContractDetails reducer, user is pushed to CreateContractDetails
   const handleChangeForSecondParty = (contractDetail, partyType) => {
     console.log('in handleChangeForSecondParty', contractDetail, partyType);
+    if (!newContractDetails.firstPartyType) {
+      alert('Please select whether you are the buyer or seller.');
+      return;
+    }
     if (partyType === 'buyer') {
       dispatch({type: 'SET_NEW_CONTRACT_DETAILS', payload: {...newContractDetails, [contractDetail]: 'buyer'}});
     } else if (partyType === 'seller') {

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -55,6 +55,12 @@ const SendToRecipient = () => {
     history.push('/dashboard');
   }
 
+  // autofill email for demo purposes
+  const autofillEmail = () => {
+    console.log('in autofillEmail');
+    dispatch({type: 'SET_NEW_CONTRACT_DETAILS', payload: {...newContractDetails, secondPartyEmail: 'christmascactus@gmail.com'}});
+  }
+
   return (
     <div>
         <Box sx={{display: 'flex', justifyContent: 'center'}}>
@@ -67,6 +73,7 @@ const SendToRecipient = () => {
             value={newContractDetails.secondPartyEmail}
             onChange={handleChangeFor('secondPartyEmail')}
           />
+          <div onClick={autofillEmail}><h5>magic button</h5></div>
         </Box>
         <br />
         <br />

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -40,6 +40,10 @@ const SendToRecipient = () => {
   // dispatching newContractDetails
   const submitNewContract = () => {
     console.log('in submitNewContract', newContractDetails);
+    if (!newContractDetails.secondPartyEmail || !newContractDetails.contractKey) {
+      alert('Please make sure you have entered the recipient email AND click the "Generate Contract Token" button.');
+      return;
+    }
     // the SendGrid email server request is called from within the addNewContract saga
     dispatch({type: 'ADD_NEW_CONTRACT', payload: newContractDetails, userAlert: userAlert});
   }
@@ -56,6 +60,7 @@ const SendToRecipient = () => {
         <Box sx={{display: 'flex', justifyContent: 'center'}}>
           <Typography variant="h3">Send to Recipient:</Typography>
           <TextField
+            required
             sx={{width: 300, marginLeft: 2}}
             helperText="Enter Recipient's Email"
             label="example@gmail.com"
@@ -100,7 +105,7 @@ const SendToRecipient = () => {
       </Container>
       <br />
       <Box sx={{display: 'flex', justifyContent: 'center'}}>
-        <Button variant="contained" color="secondary" onClick={() => setContractKey('contractKey', token)} sx={{mr: 2}}>Generate Contract Token</Button>
+        <Button variant="contained" color="secondary" onClick={() => setContractKey('contractKey', token)} sx={{mr: 2}}>Generate Contract Token*</Button>
         {
           tokenCreated ? <Typography sx={{display:"flex", alignItems:"center", justifyContent:"center"}}>Token created!</Typography> : 
           <Typography sx={{width: 200, display:"flex", alignItems:"center", justifyContent:"center"}}>

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -73,7 +73,8 @@ const SendToRecipient = () => {
             value={newContractDetails.secondPartyEmail}
             onChange={handleChangeFor('secondPartyEmail')}
           />
-          <div onClick={autofillEmail}><h5>magic button</h5></div>
+          {/* used to autofill recipient email during demo */}
+          <div style={{width: 100}} onClick={autofillEmail}><h5>magic button</h5></div>
         </Box>
         <br />
         <br />

--- a/src/redux/reducers/contract.reducer.js
+++ b/src/redux/reducers/contract.reducer.js
@@ -26,7 +26,7 @@ const newContractDetails = (state = defaultNewContract, action) => {
     console.log('in newContractDetails reducer');
     if(action.type === 'SET_NEW_CONTRACT_DETAILS') {
         return action.payload;
-    } else if (action.type === 'UNSET_USER') {
+    } else if (action.type === 'UNSET_USER' || action.type === 'SET_DEFAULT_CONTRACT') {
         return defaultNewContract;
     }
     return state;

--- a/src/redux/sagas/contract.saga.js
+++ b/src/redux/sagas/contract.saga.js
@@ -42,8 +42,9 @@ function* addNewContract(action) {
         yield put ({type: 'FETCH_CONTRACTS'});
         // SendGrid email request:
         // yield axios.post('/api/sendgrid', action.payload);
-        // user is told the contract post and email were successfull
+        // clearing contract details from newContractDetails reducer
         yield put ({type: 'SET_DEFAULT_CONTRACT'});
+        // user is told the contract post and email were successfull
         action.userAlert();
     } catch (error) {
         console.log('Error in addNewContract (saga)', error);

--- a/src/redux/sagas/contract.saga.js
+++ b/src/redux/sagas/contract.saga.js
@@ -41,8 +41,9 @@ function* addNewContract(action) {
         yield axios.post('/api/contract', action.payload);
         yield put ({type: 'FETCH_CONTRACTS'});
         // SendGrid email request:
-        // yield axios.get('/api/recipient/email', action.payload);
+        // yield axios.post('/api/sendgrid', action.payload);
         // user is told the contract post and email were successfull
+        yield put ({type: 'SET_DEFAULT_CONTRACT'});
         action.userAlert();
     } catch (error) {
         console.log('Error in addNewContract (saga)', error);


### PR DESCRIPTION
Made the following updates to create contract components:

- PartyType: added validation that requires the user to select 'buyer' or 'seller' before they can proceed
- CreateContractDetails: added validation that requires all fields with a *, added magic button to autofill form fields
- SendToRecipient: added validation that required recipient email and token creation, added magic button to autofill recipient email

Right now the magic buttons are visible so we can learn where they are leading up to the demo/decide the best placement for them.

In newContractDetails reducer, added action type 'SET_DEFAULT_CONTRACT' to return defaultContractDetails. 'SET_DEFAULT_CONTRACT' is dispatched in the addNewContract saga after the post and email. This clears the contract details reducer, so the form fields are clear when the user goes to make another contract without refreshing the page. 