### PR TITLE
Updated user router POST to insert recipient by contract key into "user" and record into "user_contract"

### DIFF
--- a/server/routes/user.router.js
+++ b/server/routes/user.router.js
@@ -18,7 +18,7 @@ router.get('/', rejectUnauthenticated, (req, res) => {
 // The only thing different from this and every other post we've seen
 // is that the password gets encrypted before being inserted
 router.post('/register', async (req, res, next) => {
-  console.log('in /api/user POST. Contract key (if set) is:', req.body.contractKey);
+  console.log('in /api/user POST. Contract key (if non-empty string) is:', req.body.contractKey);
   // const username = req.body.username
   const email = req.body.email;
   const legalName = req.body.legalName;

--- a/server/routes/user.router.js
+++ b/server/routes/user.router.js
@@ -17,21 +17,54 @@ router.get('/', rejectUnauthenticated, (req, res) => {
 // Handles POST request with new user data
 // The only thing different from this and every other post we've seen
 // is that the password gets encrypted before being inserted
-router.post('/register', (req, res, next) => {
+router.post('/register', async (req, res, next) => {
+  console.log('in /api/user POST. Contract key (if set) is:', req.body.contractKey);
   // const username = req.body.username
   const email = req.body.email;
   const legalName = req.body.legalName;
   const password = encryptLib.encryptPassword(req.body.password);
+  const contractKey = req.body.contractKey;
+  const client = await pool.connect();
 
-  const queryText = `INSERT INTO "user" (email, legal_name, password)
+  // if contractKey is empty string, inserts user without checking for contract to link by contract key 
+  if (contractKey === '') {
+    const queryText = `INSERT INTO "user" (email, legal_name, password)
     VALUES ($1, $2, $3) RETURNING id`;
-  pool
-    .query(queryText, [email, legalName, password])
-    .then(() => res.sendStatus(201))
-    .catch((err) => {
-      console.log('User registration failed: ', err);
+    pool
+      .query(queryText, [email, legalName, password])
+      .then(() => res.sendStatus(201))
+      .catch((err) => {
+        console.log('User registration failed: ', err);
+        res.sendStatus(500);
+      });
+  } else {
+    try {
+      await client.query('BEGIN');
+      // select from "contract" table by contract key, return contract id
+      const selectContract = `SELECT * FROM "contract"
+                              WHERE "contract"."contract_key" = $1;`;
+      const contract = await pool.query(selectContract, [contractKey])
+      const contractId = contract.rows[0].id;
+      console.log('contractId is:', contractId);
+      // insert into "user" table to add user, return user id
+      const insertUser = `INSERT INTO "user" (email, legal_name, password)
+                          VALUES ($1, $2, $3) RETURNING "id";`;
+      const result = await pool.query(insertUser, [email, legalName, password]);
+      const userId = result.rows[0].id;
+      console.log('userId is:', result.rows[0].id);
+      // insert into "user_contract" table with returned values of user id and contract id
+      await pool.query(`INSERT INTO "user_contract" ("user_id", "contract_id")
+                        VALUES($1, $2);`, [userId, contractId]);
+      await client.query('COMMIT'); // commit if queries succeeded
+      res.sendStatus(201); 
+    } catch (error) {
+      console.log('User registration failed: ', error);
+      await client.query('ROLLBACK');
       res.sendStatus(500);
-    });
+    } finally {
+      client.release();
+    }
+  }
 });
 
 // Handles login form authenticate/login POST


### PR DESCRIPTION
Updated user router POST to check if contractKey dispatched as part of payload object in RegisterForm.jsx is an empty string. If not, async/await is used to first retrieve contractId by contractKey from the "contract" table. 
Then the user is inserted into the "user" table by email, legal_name, and password, and userId is generated. Last a record is inserted into "user_contract" junction table using contractId and userId.

Created a temporary function in RecipientView to test dispatch of 'SET_CONTRACT_KEY', storage of contractKey in contractKey reducer, navigation of recipient to '/registration', and successful linking of recipient to contract by contract key in database upon registration. Removed test function and will add back when RecipientView is built out. 