### PR TITLE
Updated contract saga with function to PUT/UDPATE contract status and added onClick function to Decline button in RecipientView

### DIFF
--- a/src/components/RecipientView/RecipientView.jsx
+++ b/src/components/RecipientView/RecipientView.jsx
@@ -59,33 +59,39 @@ function RecipientView() {
 
   return (
     <div>
+      <Typography variant="h5" color="secondary" sx={{ textAlign: "center" }}>
+        {contractDetails.contract_status}
+      </Typography>
+      <br />
       <Typography variant="h3" sx={{ textAlign: "center" }}>
         Recipient View
       </Typography>
       <br />
-      <Typography variant="h5" color="secondary" sx={{ textAlign: "center" }}>
-        contract {contractDetails.contract_status}
-      </Typography>
       <br />
       <ContractPreview contractDetails={contractDetails} />
+      <br />
+      <br />
       <div>
-        <br></br>
-        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-          <Button
-            variant="contained"
-            onClick={acceptContract}
-            sx={{ marginRight: 1, width: 200 }}
-          >
-            Accept
-          </Button>
-          <Button
-            variant="contained"
-            onClick={confirmDecline}
-            sx={{ marginLeft: 1, width: 200 }}
-          >
-            Decline
-          </Button>
-        </Box>
+        {/* conditional checks that contract status is pending and renders Accept, Decline buttons */}
+        {contractDetails.contract_status === 'pending' ?
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <Button
+              variant="contained"
+              onClick={acceptContract}
+              sx={{ marginRight: 1, width: 200 }}
+            >
+              Accept
+            </Button>
+            <Button
+              variant="contained"
+              onClick={confirmDecline}
+              sx={{ marginLeft: 1, width: 200 }}
+            >
+              Decline
+            </Button>
+          </Box> :
+          <></>
+        }
       </div>
     </div>
   );

--- a/src/components/RecipientView/RecipientView.jsx
+++ b/src/components/RecipientView/RecipientView.jsx
@@ -35,7 +35,7 @@ function RecipientView() {
     }
   };
 
-  // dispatches 'UPDATE_CONTRACT_STATUS' with payload of contract object, alerts contract recipient that contract has been declined
+  // dispatches 'UPDATE_CONTRACT_STATUS' with payload of contract object and function handleContractStatusUpdate
   const declineContract = () => {
     console.log('in declineContract. Contract id to decline is:', contractDetails.id);
     dispatch({
@@ -45,8 +45,15 @@ function RecipientView() {
         contract_status: 'declined',
         contract_approval: false,
         second_party_signature: null
-      }
+      },
+      handleContractStatusUpdate
     });
+  }
+
+  // passed as part of declineContract, contract by key re-renders in RecipientView with updated status and alerts recipient of successful decline
+  const handleContractStatusUpdate = () => {
+    console.log('in handleContractStatusUpdate');
+    dispatch({ type: 'FETCH_RECIPIENT_CONTRACT', payload: searchContractKey });
     alert('Thank you! The contract has been declined.');
   }
 

--- a/src/components/RecipientView/RecipientView.jsx
+++ b/src/components/RecipientView/RecipientView.jsx
@@ -31,18 +31,33 @@ function RecipientView() {
   const confirmDecline = () => {
     console.log('in confirmDecline');
     if (window.confirm('Are you sure you want to decline this contract?')) {
-
+      declineContract();
     }
   };
+
+  // dispatches 'UPDATE_CONTRACT_STATUS' with payload of contract object, alerts contract recipient that contract has been declined
+  const declineContract = () => {
+    console.log('in declineContract. Contract id to decline is:', contractDetails.id);
+    dispatch({
+      type: 'UPDATE_CONTRACT_STATUS',
+      payload: {
+        id: contractDetails.id,
+        contract_status: 'declined',
+        contract_approval: false,
+        second_party_signature: null
+      }
+    });
+    alert('Thank you! The contract has been declined.');
+  }
 
   return (
     <div>
       <Typography variant="h3" sx={{ textAlign: "center" }}>
-        Recipient View 
+        Recipient View
       </Typography>
       <br />
       <Typography variant="h5" color="secondary" sx={{ textAlign: "center" }}>
-        contract {contractDetails.contract_status} 
+        contract {contractDetails.contract_status}
       </Typography>
       <br />
       <ContractPreview contractDetails={contractDetails} />

--- a/src/components/RecipientView/RecipientView.jsx
+++ b/src/components/RecipientView/RecipientView.jsx
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router-dom';
 import ContractPreview from '../ContractPreview/ContractPreview';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
 
 function RecipientView() {
   const history = useHistory();
@@ -26,9 +27,24 @@ function RecipientView() {
     history.push('/registration');
   }
 
+  // prompts recipient to confirm before contract is declined
+  const confirmDecline = () => {
+    console.log('in confirmDecline');
+    if (window.confirm('Are you sure you want to decline this contract?')) {
+
+    }
+  };
+
   return (
     <div>
-      <h1>RecipientView</h1>
+      <Typography variant="h3" sx={{ textAlign: "center" }}>
+        Recipient View 
+      </Typography>
+      <br />
+      <Typography variant="h5" color="secondary" sx={{ textAlign: "center" }}>
+        contract {contractDetails.contract_status} 
+      </Typography>
+      <br />
       <ContractPreview contractDetails={contractDetails} />
       <div>
         <br></br>
@@ -42,6 +58,7 @@ function RecipientView() {
           </Button>
           <Button
             variant="contained"
+            onClick={confirmDecline}
             sx={{ marginLeft: 1, width: 200 }}
           >
             Decline

--- a/src/redux/sagas/contract.saga.js
+++ b/src/redux/sagas/contract.saga.js
@@ -68,7 +68,6 @@ function* updateContractStatus(action) {
     }   
 }
 
-
 function* contractSaga() {
     yield takeLatest('FETCH_CONTRACTS', fetchContracts);
     yield takeLatest('FETCH_CONTRACT_DETAILS', fetchContractDetails);

--- a/src/redux/sagas/contract.saga.js
+++ b/src/redux/sagas/contract.saga.js
@@ -62,6 +62,7 @@ function* updateContractStatus(action) {
     try {
         console.log('in updateContractStatus (saga). Contract object to update is:', action.payload);
         yield axios.put('/api/contract', action.payload);
+        action.handleContractStatusUpdate();
     } catch (error) {
         console.log('Error in updateContractStatus (saga)', error);
         alert('Something went wrong updating the contract status.');

--- a/src/redux/sagas/contract.saga.js
+++ b/src/redux/sagas/contract.saga.js
@@ -57,11 +57,24 @@ function* addNewContract(action) {
     }
 }
 
+function* updateContractStatus(action) {
+    // payload is contract object that includes updated properties for signature and contract status
+    try {
+        console.log('in updateContractStatus (saga). Contract object to update is:', action.payload);
+        yield axios.put('/api/contract', action.payload);
+    } catch (error) {
+        console.log('Error in updateContractStatus (saga)', error);
+        alert('Something went wrong updating the contract status.');
+    }   
+}
+
+
 function* contractSaga() {
     yield takeLatest('FETCH_CONTRACTS', fetchContracts);
     yield takeLatest('FETCH_CONTRACT_DETAILS', fetchContractDetails);
     yield takeLatest('FETCH_RECIPIENT_CONTRACT', fetchRecipientContract);
     yield takeLatest('ADD_NEW_CONTRACT', addNewContract);
+    yield takeLatest('UPDATE_CONTRACT_STATUS', updateContractStatus);
 }
 
 export default contractSaga;


### PR DESCRIPTION
Added updateContractStatus generator function to contract saga that fires on 'UPDATE_CONTRACT_STATUS' and makes server PUT request to '/api/contract'.  Payload is contract object that includes updated properties for signature and contract status. Successfully tested Decline from RecipientView with a draft of the server contract router PUT. Removed draft of contract router PUT as it will be submitted on a separate PR.

Added onClick function confirmDecline to Decline button in RecipientView that prompts recipient to confirm before declining and then calls declineContract when confirmed. declineContract dispatches 'UPDATE_CONTRACT_STATUS' with a payload of the updated contract object including properties of contract_status as 'declined' and second_party_signature as null and function handleContractStatusUpdate. 

handleContractStatusUpdate dispatches 'FETCH_RECIPIENT_CONTRACT' and alerts recipient contract has been successfully declined. Added handleContractStatusUpdate() to updateContractStatus generator function in contract saga so alert and re-render will occur after successful contract status update.



