### PR TITLE
updated legal doc template, added explanation of contract token

### DIFF
--- a/src/components/CreateContract/PartyType.jsx
+++ b/src/components/CreateContract/PartyType.jsx
@@ -27,10 +27,10 @@ const PartyType = () => {
   const handleChangeFor = (key) => (event) => {
     console.log('in handleChangeFor', event.target.value);
     // secondParty set to the opposite of the firstPartyType
-    if (event.target.value === 'buyer') {
-      setSecondParty('seller');
-    } else if (event.target.value === 'seller') {
-      setSecondParty('buyer');
+    if (event.target.value === 'Buyer') {
+      setSecondParty('Seller');
+    } else if (event.target.value === 'Seller') {
+      setSecondParty('Buyer');
     }
     // dispatching to newContractDetails reducer
     dispatch({type: 'SET_NEW_CONTRACT_DETAILS', payload: {...newContractDetails, [key]: event.target.value}});
@@ -43,10 +43,10 @@ const PartyType = () => {
       alert('Please select whether you are the buyer or seller.');
       return;
     }
-    if (partyType === 'buyer') {
-      dispatch({type: 'SET_NEW_CONTRACT_DETAILS', payload: {...newContractDetails, [contractDetail]: 'buyer'}});
-    } else if (partyType === 'seller') {
-      dispatch({type: 'SET_NEW_CONTRACT_DETAILS', payload: {...newContractDetails, [contractDetail]: 'seller'}});
+    if (partyType === 'Buyer') {
+      dispatch({type: 'SET_NEW_CONTRACT_DETAILS', payload: {...newContractDetails, [contractDetail]: 'Buyer'}});
+    } else if (partyType === 'Seller') {
+      dispatch({type: 'SET_NEW_CONTRACT_DETAILS', payload: {...newContractDetails, [contractDetail]: 'Seller'}});
     }
     // user is pushed to CreateContractDetails
     history.push('/create-contract-details');
@@ -89,8 +89,8 @@ const PartyType = () => {
               value={newContractDetails.firstPartyType}
               onChange={handleChangeFor('first_party_type')}
             >
-              <FormControlLabel value="buyer" control={<Radio />} label="Buyer" />
-              <FormControlLabel value="seller" control={<Radio />} label="Seller" />
+              <FormControlLabel value="Buyer" control={<Radio />} label="Buyer" />
+              <FormControlLabel value="Seller" control={<Radio />} label="Seller" />
               </RadioGroup>
             </FormControl>
           </Grid>

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -13,6 +13,7 @@ import PersonIcon from '@mui/icons-material/Person';
 import EditIcon from '@mui/icons-material/Edit';
 import SendIcon from '@mui/icons-material/Send';
 import SummarizeIcon from '@mui/icons-material/Summarize';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 
 const SendToRecipient = () => {
 
@@ -58,6 +59,12 @@ const SendToRecipient = () => {
     console.log('in userAlert');
     alert('Your contact has been created, and the recipient has been sent an email inviting them to view the contract details.');
     history.push('/dashboard');
+  }
+
+  // explanation of what the contract token is used for
+  const contractTokenAlert = () => {
+    console.log('in contractTokenAlert');
+    alert('The contract token is a unique key that is associated with this contract. The recipient will receive an email with a link to view the details of this contract. The contract token is used in that link to ensure that they access this document securely.')
   }
 
   // autofill email for demo purposes
@@ -146,6 +153,7 @@ const SendToRecipient = () => {
             Click to generate contract token for recipient access.
           </Typography>
         }
+        <Typography onClick={contractTokenAlert}><HelpOutlineIcon /></Typography>
       </Box>
       <br />
       <Box sx={{display: 'flex', justifyContent: 'center'}}>

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -153,7 +153,7 @@ const SendToRecipient = () => {
             Click to generate contract token for recipient access.
           </Typography>
         }
-        <Typography onClick={contractTokenAlert}><HelpOutlineIcon /></Typography>
+        <Typography sx={{ml: 2}} onClick={contractTokenAlert}><HelpOutlineIcon /></Typography>
       </Box>
       <br />
       <Box sx={{display: 'flex', justifyContent: 'center'}}>

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -109,15 +109,15 @@ const SendToRecipient = () => {
             <Typography sx={{textAlign: 'center'}}>THIS BILL OF SALE is executed on {newContractDetails.item_pickup_date} by and between {user.legal_name} (hereinafter referred to as the "{newContractDetails.first_party_type}")</Typography>
             <Typography sx={{textAlign: 'center'}}>and RECIPIENT LEGAL NAME (hereinafter referred to as the "{newContractDetails.second_party_type}").</Typography>
             <br />
-            <Typography sx={{textAlign: 'center'}}>The Seller hereby agrees to transfer to Buyer all rights of the seller in the following property:</Typography>
+            <Typography sx={{textAlign: 'center'}}>The Seller hereby agrees to transfer to the Buyer all rights of the Seller in the following property:</Typography>
             <Typography sx={{textAlign: 'center'}}>{newContractDetails.item_name}: {newContractDetails.item_description}</Typography>
             <br />
-            <Typography sx={{textAlign: 'center'}}>For and in consideration of a total purchase price of ${newContractDetails.item_price}, receipt of which is hereby acknowledged by Seller. The form of payment used will be cash and sales tax is included in the purchase price of the above-mentioned property.</Typography>
+            <Typography sx={{textAlign: 'center'}}>For and in consideration of a total purchase price of ${newContractDetails.item_price}, an amount agreed upon by the Seller and the Buyer. The form of payment used will be cash and sales tax is included in the purchase price of the above-mentioned property.</Typography>
             <br />
             <Typography sx={{textAlign: 'center'}}>The Seller hereby affirms that the above information about this property is accurate to the best of their knowledge, and by their signature below certifies they are the lawful owner of the property with the ability to sell it as they see fit.</Typography>
-            <Typography sx={{textAlign: 'center'}}>The sale and transfer of property is hereby made on an "AS IS" condition, without any express or implied warranties, with no recourse to the Seller, provided that Seller can issue proof that they have the title to the property without any liens or encumbrances. The Buyer has been given the opportunity to inspect, or has inspected, the property as described above. The Buyer agree to accept all property in its existing state.</Typography>
+            <Typography sx={{textAlign: 'center'}}>The sale and transfer of property is hereby made on an "AS IS" condition, without any express or implied warranties, with no recourse to the Seller, provided that the Seller can issue proof that they have the title to the property without any liens or encumbrances. The Buyer agrees to accept all property in its existing state.</Typography>
             <br />
-            <Typography sx={{textAlign: 'center'}}>Notes made by {newContractDetails.first_party_type} regarding the above property:</Typography>
+            <Typography sx={{textAlign: 'center'}}>Notes regarding the above property and/or the transaction:</Typography>
             <Typography sx={{textAlign: 'center'}}>{newContractDetails.contract_notes}</Typography>
             <br />
             <Typography sx={{textAlign: 'center'}}>"AS IS" images of the above property provided by the {newContractDetails.first_party_type}:</Typography>
@@ -128,10 +128,10 @@ const SendToRecipient = () => {
             </Box>
             <br />
             <Typography sx={{textAlign: 'center'}}>The above property will be transferred on: {formattedPickupDate}</Typography>
-            <Typography sx={{textAlign: 'center'}}>The seller and buyer will meet in {newContractDetails.item_pickup_location} to transfer the above property.</Typography>
+            <Typography sx={{textAlign: 'center'}}>The Seller and Buyer will meet in {newContractDetails.item_pickup_location} to conduct the transaction for the above property.</Typography>
             <br />
             <Box sx={{ p: 2, border: '1px solid grey' }}>
-              <Typography sx={{textAlign: 'center'}}>IN WITNESS THEREOF, the parties executed this Bill of Sale on {newContractDetails.item_pickup_date},</Typography>
+              <Typography sx={{textAlign: 'center'}}>IN WITNESS THEREOF, the parties execute this Bill of Sale:</Typography>
               <Typography sx={{textAlign: 'center'}}>{newContractDetails.first_party_type} Signature: {newContractDetails.first_party_signature}</Typography>
               <Typography sx={{textAlign: 'center'}}>{newContractDetails.second_party_type} Signature: {newContractDetails.second_party_signature}</Typography>
             </Box>

--- a/src/components/CreateContract/SendToRecipient.jsx
+++ b/src/components/CreateContract/SendToRecipient.jsx
@@ -103,23 +103,24 @@ const SendToRecipient = () => {
         <br />
         <br />
         <Container sx={{display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
-          <Paper elevation={10} sx={{width: 700, padding: 2, display: 'flex', flexDirection: 'column'}}>
-            <Typography variant="h6" sx={{textAlign: 'center'}}>{newContractDetails.contract_title} Agreement</Typography>
-            {/* user.username will be changed to user.legalName when registration/login is working */}
-            <Typography sx={{textAlign: 'center'}}>{user.legal_name} (the "{newContractDetails.first_party_type}") does hereby sell, assign, and transfer to</Typography>
-            <Typography sx={{textAlign: 'center'}}>*recipient legal name* (the "{newContractDetails.second_party_type}") the following property:</Typography>
+          <Paper elevation={10} sx={{width: 700, padding: 4, display: 'flex', flexDirection: 'column'}}>
+            <Typography sx={{textAlign: 'center'}}>Legal Contract for {newContractDetails.contract_title}</Typography>
+            <Typography variant="h6" sx={{textAlign: 'center'}}>Bill of Sale</Typography>
+            <Typography sx={{textAlign: 'center'}}>THIS BILL OF SALE is executed on {newContractDetails.item_pickup_date} by and between {user.legal_name} (hereinafter referred to as the "{newContractDetails.first_party_type}")</Typography>
+            <Typography sx={{textAlign: 'center'}}>and RECIPIENT LEGAL NAME (hereinafter referred to as the "{newContractDetails.second_party_type}").</Typography>
             <br />
+            <Typography sx={{textAlign: 'center'}}>The Seller hereby agrees to transfer to Buyer all rights of the seller in the following property:</Typography>
             <Typography sx={{textAlign: 'center'}}>{newContractDetails.item_name}: {newContractDetails.item_description}</Typography>
             <br />
-            <Typography sx={{textAlign: 'center'}}>for a TOTAL AMOUNT OF ${newContractDetails.item_price}</Typography>
+            <Typography sx={{textAlign: 'center'}}>For and in consideration of a total purchase price of ${newContractDetails.item_price}, receipt of which is hereby acknowledged by Seller. The form of payment used will be cash and sales tax is included in the purchase price of the above-mentioned property.</Typography>
             <br />
-            <Typography sx={{textAlign: 'center'}}>The seller warrants that they are the legal owner of the property and that it is being transferred to the buyer free and clear of any liens or encumbrances.</Typography>
-            <Typography sx={{textAlign: 'center'}}>The above property is sold on an "AS IS" basis. The seller makes no warranites, express or implied (except as specially stated in this document).</Typography>
+            <Typography sx={{textAlign: 'center'}}>The Seller hereby affirms that the above information about this property is accurate to the best of their knowledge, and by their signature below certifies they are the lawful owner of the property with the ability to sell it as they see fit.</Typography>
+            <Typography sx={{textAlign: 'center'}}>The sale and transfer of property is hereby made on an "AS IS" condition, without any express or implied warranties, with no recourse to the Seller, provided that Seller can issue proof that they have the title to the property without any liens or encumbrances. The Buyer has been given the opportunity to inspect, or has inspected, the property as described above. The Buyer agree to accept all property in its existing state.</Typography>
             <br />
-            <Typography sx={{textAlign: 'center'}}>Notes regarding the above property:</Typography>
+            <Typography sx={{textAlign: 'center'}}>Notes made by {newContractDetails.first_party_type} regarding the above property:</Typography>
             <Typography sx={{textAlign: 'center'}}>{newContractDetails.contract_notes}</Typography>
             <br />
-            <Typography sx={{textAlign: 'center'}}>"AS IS" images of the above property provided by the seller:</Typography>
+            <Typography sx={{textAlign: 'center'}}>"AS IS" images of the above property provided by the {newContractDetails.first_party_type}:</Typography>
             <br />
             <Box sx={{display: 'flex', justifyContent: 'center', p: 2, border: '1px solid grey' }}>
               {/* images will be the user-uploaded images once that functionality is implemented */}
@@ -130,6 +131,7 @@ const SendToRecipient = () => {
             <Typography sx={{textAlign: 'center'}}>The seller and buyer will meet in {newContractDetails.item_pickup_location} to transfer the above property.</Typography>
             <br />
             <Box sx={{ p: 2, border: '1px solid grey' }}>
+              <Typography sx={{textAlign: 'center'}}>IN WITNESS THEREOF, the parties executed this Bill of Sale on {newContractDetails.item_pickup_date},</Typography>
               <Typography sx={{textAlign: 'center'}}>{newContractDetails.first_party_type} Signature: {newContractDetails.first_party_signature}</Typography>
               <Typography sx={{textAlign: 'center'}}>{newContractDetails.second_party_type} Signature: {newContractDetails.second_party_signature}</Typography>
             </Box>


### PR DESCRIPTION
Updated the legal doc template in SendToRecipient to closely match the FormSwift example that Gafar shared. 

Updated the values of the radio buttons in PartyType to be 'Buyer' and 'Seller', capitalizing the first letters to match the formatting of the legal doc when the party type variables are referenced.

Added a '?' icon next to the contract key generate button. When clicked, an alert explains to the user why the contract token is needed.