### PR TITLE
updated ContractDetails and ContractPreview to include conditional rendering for user actions

### DIFF
--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -23,11 +23,11 @@ function ContractDetails() {
 
   const [userAction, setUserAction] = useState(false);
 
-  const checkForUserAction = () => {
-    console.log('in checkForUserAction', contractDetails.contract_status);
-    if(contractDetails.contract_status === 'pending_first_party_response' && contractDetails.first_party_name === user.legal_name) {
+  const checkForUserAction = (contractInput) => {
+    console.log('in checkForUserAction', contractInput.contract_status);
+    if(contractInput.contract_status === 'pending_first_party_response' && contractInput.first_party_name === user.legal_name) {
       setUserAction(true);
-    } else if (contractDetails.contract_status === 'pending_second_party_response' && contractDetails.second_party_name === user.legal_name) {
+    } else if (contractInput.contract_status === 'pending_second_party_response' && contractInput.second_party_name === user.legal_name) {
       setUserAction(true);
     }
   }
@@ -50,7 +50,6 @@ function ContractDetails() {
       <br />
 
       <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-
         {
           userAction ? <Typography>needs accept and decline buttons</Typography> : 
           <Button

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -44,7 +44,10 @@ function ContractDetails() {
       <br />
 
 
-      <ContractPreview contractDetails={contractDetails} />
+      <ContractPreview 
+        contractDetails={contractDetails} 
+        userAction={userAction}
+      />
 
       <br />
       <br />

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -19,6 +19,8 @@ function ContractDetails() {
   // need user reducer in the case we need to pull out the user's email? 
   // const user = useSelector((store) => store.user)
 
+  const [secondPartySignature, setSecondPartySignature] = useState('');
+
   useEffect(() => {
     dispatch({ type: 'FETCH_CONTRACT_DETAILS', payload: contractId, checkForUserAction: checkForUserAction});
   }, [contractId])
@@ -33,6 +35,11 @@ function ContractDetails() {
     } else if (contractInput.contract_status === 'pending_second_party_response' && contractInput.second_party_name === user.legal_name) {
       setUserAction(true);
     }
+  }
+
+  const finalizeContract = () => {
+    console.log('in finalizeContract, second party signature:', secondPartySignature);
+    // dispatch to contract saga to update contract status and second party signature
   }
 
   return (
@@ -56,21 +63,9 @@ function ContractDetails() {
       <br />
         {
           userAction ?  <>
-                          <Grid
-                            container
-                            spacing={2}
-                            direction="column"
-                            alignItems="center"
-                            justifyContent="center"
-                          >
+                          <Grid container spacing={2} direction="column" alignItems="center" justifyContent="center">
                             <Grid item>
-                              <TextField 
-                                required
-                                fullWidth
-                                label='Your Signature'
-                                size='small'
-                                sx={{width: 400}}
-                              /> 
+                              <TextField required fullWidth label='Your Signature' size='small' sx={{width: 400}} onChange={(event) => setSecondPartySignature(event.target.value)}/> 
                             </Grid>
                           </Grid>
                           <br />
@@ -81,7 +76,8 @@ function ContractDetails() {
                           <Box sx={{ display: 'flex', justifyContent: 'center' }}>
                             <Button
                               variant="contained"
-                              // onClick to update contract_status to 'accepted', trigger PDF generation, and show success alert to user
+                              // onClick to update contract_status to 'accepted' and add second party signature, trigger PDF generation, and show success alert to user
+                              onClick={(event) => finalizeContract()}
                               sx={{ marginRight: 1, width: 200, height: 60 }}
                             >
                               Sign and Finalize Contract
@@ -105,7 +101,6 @@ function ContractDetails() {
                           Back to Dashboard
                         </Button>
                       </Box>
-
         }
     </div>
   );

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -54,7 +54,7 @@ function ContractDetails() {
           userAction ?  <div>
                           <Button
                             variant="contained"
-                            // onClick to updated contract_status and trigger PDF generation
+                            // onClick to update contract_status to 'accepted' and trigger PDF generation
                             sx={{ marginRight: 1, width: 200, height: 60 }}
                           >
                             Sign and Finalize Contract
@@ -62,7 +62,7 @@ function ContractDetails() {
                           <Button
                             variant="contained"
                             color="error"
-                            // onClick to update contract_status and return user to /dashboard
+                            // onClick to update contract_status to 'declined', trigger a declined contract confirmation alert, and return user to /dashboard
                             sx={{ marginLeft: 1, width: 200, height: 60 }}
                           >
                             Decline Contract

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Grid from '@mui/material/Grid';
 
 import Button from '@mui/material/Button';
 
@@ -52,39 +54,59 @@ function ContractDetails() {
 
       <br />
       <br />
-
-      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
         {
-          userAction ?  <div>
-                          <Button
-                            variant="contained"
-                            // onClick to update contract_status to 'accepted', trigger PDF generation, and show success alert to user
-                            sx={{ marginRight: 1, width: 200, height: 60 }}
+          userAction ?  <>
+                          <Grid
+                            container
+                            spacing={2}
+                            direction="column"
+                            alignItems="center"
+                            justifyContent="center"
                           >
-                            Sign and Finalize Contract
-                          </Button>
-                          <Button
-                            variant="contained"
-                            color="error"
-                            // onClick to update contract_status to 'declined', trigger a declined contract confirmation alert, and return user to /dashboard
-                            sx={{ marginLeft: 1, width: 200, height: 60 }}
-                          >
-                            Decline Contract
-                          </Button> 
-                      </div> : 
-          <Button
-            variant="contained"
-            onClick={(event) => history.push('/dashboard')}
-            sx={{ marginRight: 1, width: 200 }}
-          >
-            Back to Dashboard
-          </Button>
+                            <Grid item>
+                              <TextField 
+                                required
+                                fullWidth
+                                label='Your Signature'
+                                size='small'
+                                sx={{width: 400}}
+                              /> 
+                            </Grid>
+                          </Grid>
+                          <br />
+                          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                            <Typography sx={{width: 400, display:"flex", alignItems:"center", justifyContent:"center"}}>By typing your name, you are agreeing that your typed signature has the same authority as a handwritten signature.</Typography>
+                          </Box>
+                          <br />
+                          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                            <Button
+                              variant="contained"
+                              // onClick to update contract_status to 'accepted', trigger PDF generation, and show success alert to user
+                              sx={{ marginRight: 1, width: 200, height: 60 }}
+                            >
+                              Sign and Finalize Contract
+                            </Button>
+                            <Button
+                              variant="contained"
+                              color="error"
+                              // onClick to update contract_status to 'declined', trigger a declined contract confirmation alert, and return user to /dashboard
+                              sx={{ marginLeft: 1, width: 200, height: 60 }}
+                            >
+                              Decline Contract
+                            </Button> 
+                          </Box>
+                      </> : 
+                      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                        <Button
+                          variant="contained"
+                          onClick={(event) => history.push('/dashboard')}
+                          sx={{ marginRight: 1, width: 200 }}
+                        >
+                          Back to Dashboard
+                        </Button>
+                      </Box>
+
         }
-
-      </Box>
-
-
-
     </div>
   );
 }

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -51,7 +51,23 @@ function ContractDetails() {
 
       <Box sx={{ display: 'flex', justifyContent: 'center' }}>
         {
-          userAction ? <Typography>needs accept and decline buttons</Typography> : 
+          userAction ?  <div>
+                          <Button
+                            variant="contained"
+                            onClick={(event) => history.push('/dashboard')}
+                            sx={{ marginRight: 1, width: 200, height: 60 }}
+                          >
+                            Sign and Finalize Contract
+                          </Button>
+                          <Button
+                            variant="contained"
+                            color="error"
+                            onClick={(event) => history.push('/dashboard')}
+                            sx={{ marginLeft: 1, width: 200, height: 60 }}
+                          >
+                            Decline Contract
+                          </Button> 
+                      </div> : 
           <Button
             variant="contained"
             onClick={(event) => history.push('/dashboard')}

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -56,7 +56,6 @@ function ContractDetails() {
 
       <ContractPreview 
         contractDetails={contractDetails} 
-        userAction={userAction}
       />
 
       <br />

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -54,7 +54,7 @@ function ContractDetails() {
           userAction ?  <div>
                           <Button
                             variant="contained"
-                            onClick={(event) => history.push('/dashboard')}
+                            // onClick to updated contract_status and trigger PDF generation
                             sx={{ marginRight: 1, width: 200, height: 60 }}
                           >
                             Sign and Finalize Contract
@@ -62,7 +62,7 @@ function ContractDetails() {
                           <Button
                             variant="contained"
                             color="error"
-                            onClick={(event) => history.push('/dashboard')}
+                            // onClick to update contract_status and return user to /dashboard
                             sx={{ marginLeft: 1, width: 200, height: 60 }}
                           >
                             Decline Contract

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -13,14 +13,24 @@ function ContractDetails() {
   const history = useHistory();
   const contractDetails = useSelector(store => store.contract.selectedContract)
   const { contractId } = useParams();
+  const user = useSelector(store => store.user);
   // need user reducer in the case we need to pull out the user's email? 
   // const user = useSelector((store) => store.user)
 
   useEffect(() => {
-    dispatch({ type: 'FETCH_CONTRACT_DETAILS', payload: contractId })
+    dispatch({ type: 'FETCH_CONTRACT_DETAILS', payload: contractId, checkForUserAction: checkForUserAction});
   }, [contractId])
 
+  const [userAction, setUserAction] = useState(false);
 
+  const checkForUserAction = () => {
+    console.log('in checkForUserAction', contractDetails.contract_status);
+    if(contractDetails.contract_status === 'pending_first_party_response' && contractDetails.first_party_name === user.legal_name) {
+      setUserAction(true);
+    } else if (contractDetails.contract_status === 'pending_second_party_response' && contractDetails.second_party_name === user.legal_name) {
+      setUserAction(true);
+    }
+  }
 
   return (
     <div>
@@ -40,13 +50,18 @@ function ContractDetails() {
       <br />
 
       <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-        <Button
-          variant="contained"
-          onClick={(event) => history.push('/dashboard')}
-          sx={{ marginRight: 1, width: 200 }}
-        >
-          Back to Dashboard
-        </Button>
+
+        {
+          userAction ? <Typography>needs accept and decline buttons</Typography> : 
+          <Button
+            variant="contained"
+            onClick={(event) => history.push('/dashboard')}
+            sx={{ marginRight: 1, width: 200 }}
+          >
+            Back to Dashboard
+          </Button>
+        }
+
       </Box>
 
 

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -58,7 +58,7 @@ function ContractDetails() {
           userAction ?  <div>
                           <Button
                             variant="contained"
-                            // onClick to update contract_status to 'accepted' and trigger PDF generation
+                            // onClick to update contract_status to 'accepted', trigger PDF generation, and show success alert to user
                             sx={{ marginRight: 1, width: 200, height: 60 }}
                           >
                             Sign and Finalize Contract

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -23,6 +23,7 @@ function ContractDetails() {
 
   const [userAction, setUserAction] = useState(false);
 
+  // checking if action is required from the logged in user
   const checkForUserAction = (contractInput) => {
     console.log('in checkForUserAction', contractInput.contract_status);
     if(contractInput.contract_status === 'pending_first_party_response' && contractInput.first_party_name === user.legal_name) {

--- a/src/components/ContractPreview/ContractPreview.jsx
+++ b/src/components/ContractPreview/ContractPreview.jsx
@@ -107,20 +107,7 @@ function ContractPreview({contractDetails, userAction}) {
                         <TableRow>
                             <TableCell sx={{ width: 150 }} align="left">
                             <Typography>Second Party's Signature:</Typography></TableCell>
-                            <TableCell align="left">
-                                {userAction ?   <div>
-                                                    <TextField 
-                                                        required
-                                                        label='Your Signature'
-                                                        size='small'
-                                                        // value={newContractDetails.second_party_signature}
-                                                        // onChange={handleChangeFor('second_party_signature')}
-                                                    /> 
-                                                    <Typography>By typing your name, you are agreeing that your typed signature has the same authority as a handwritten signature.</Typography>
-                                                </div>
-                                                :
-                                contractDetails.second_party_signature}
-                            </TableCell>
+                            <TableCell align="left">{contractDetails.second_party_signature}</TableCell>
                         </TableRow>
 
                         <TableRow>

--- a/src/components/ContractPreview/ContractPreview.jsx
+++ b/src/components/ContractPreview/ContractPreview.jsx
@@ -11,6 +11,7 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
 
 // Basic functional component structure for React with default state
@@ -106,7 +107,20 @@ function ContractPreview({contractDetails, userAction}) {
                         <TableRow>
                             <TableCell sx={{ width: 150 }} align="left">
                             <Typography>Second Party's Signature:</Typography></TableCell>
-                            <TableCell align="left">{contractDetails.second_party_signature}</TableCell>
+                            <TableCell align="left">
+                                {userAction ?   <div>
+                                                    <TextField 
+                                                        required
+                                                        label='Your Signature'
+                                                        size='small'
+                                                        // value={newContractDetails.second_party_signature}
+                                                        // onChange={handleChangeFor('second_party_signature')}
+                                                    /> 
+                                                    <Typography>By typing your name, you are agreeing that your typed signature has the same authority as a handwritten signature.</Typography>
+                                                </div>
+                                                :
+                                contractDetails.second_party_signature}
+                            </TableCell>
                         </TableRow>
 
                         <TableRow>

--- a/src/components/ContractPreview/ContractPreview.jsx
+++ b/src/components/ContractPreview/ContractPreview.jsx
@@ -16,7 +16,7 @@ import Box from '@mui/material/Box';
 // Basic functional component structure for React with default state
 // value setup. When making a new component be sure to replace the
 // component name TemplateFunction with the name for the new component.
-function ContractPreview({contractDetails}) {
+function ContractPreview({contractDetails, userAction}) {
   // Using hooks we're creating local state for a "heading" variable with
   // a default value of 'Functional Component'
   const store = useSelector((store) => store);

--- a/src/components/ContractPreview/ContractPreview.jsx
+++ b/src/components/ContractPreview/ContractPreview.jsx
@@ -11,13 +11,11 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
-import TextField from '@mui/material/TextField';
-import Box from '@mui/material/Box';
 
 // Basic functional component structure for React with default state
 // value setup. When making a new component be sure to replace the
 // component name TemplateFunction with the name for the new component.
-function ContractPreview({contractDetails, userAction}) {
+function ContractPreview({contractDetails}) {
   // Using hooks we're creating local state for a "heading" variable with
   // a default value of 'Functional Component'
   const store = useSelector((store) => store);

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -43,7 +43,7 @@ function Dashboard() {
         <div>
           {userContracts.map(contract => {
             //renders pending contracts
-            if (contract.contract_status === 'pending')
+            if (contract.contract_status === 'pending_second_party_response')
               return <ContractCard contract={contract} key={contract.id}/>
           })}
         </div>

--- a/src/components/RecipientView/RecipientView.jsx
+++ b/src/components/RecipientView/RecipientView.jsx
@@ -73,7 +73,7 @@ function RecipientView() {
       <br />
       <div>
         {/* conditional checks that contract status is pending and renders Accept, Decline buttons */}
-        {contractDetails.contract_status === 'pending' ?
+        {contractDetails.contract_status === 'pending_second_party_response' ?
           <Box sx={{ display: 'flex', justifyContent: 'center' }}>
             <Button
               variant="contained"

--- a/src/redux/reducers/contract.reducer.js
+++ b/src/redux/reducers/contract.reducer.js
@@ -19,7 +19,7 @@ const defaultNewContract = {
     item_image_description: '',
     first_party_signature: '',
     contract_key: '',
-    contract_status: 'pending'
+    contract_status: 'pending_second_party_response'
 };
 
 const newContractDetails = (state = defaultNewContract, action) => {

--- a/src/redux/sagas/contract.saga.js
+++ b/src/redux/sagas/contract.saga.js
@@ -15,7 +15,6 @@ function* fetchContractDetails(action){
     try{
         const contractDetails = yield axios.get(`/api/contract/${action.payload}`);
         yield put({ type: 'SET_CONTRACT_DETAILS', payload: contractDetails.data});
-        console.log('before checkForUserAction');
         action.checkForUserAction(contractDetails.data);
     } catch (error) {
         console.log('Error in fetchContractDetails (saga)', error);

--- a/src/redux/sagas/contract.saga.js
+++ b/src/redux/sagas/contract.saga.js
@@ -15,6 +15,7 @@ function* fetchContractDetails(action){
     try{
         const contractDetails = yield axios.get(`/api/contract/${action.payload}`);
         yield put({ type: 'SET_CONTRACT_DETAILS', payload: contractDetails.data});
+        action.checkForUserAction();
     } catch (error) {
         console.log('Error in fetchContractDetails (saga)', error);
         alert('Something went wrong fetching the selected contract details');

--- a/src/redux/sagas/contract.saga.js
+++ b/src/redux/sagas/contract.saga.js
@@ -15,7 +15,8 @@ function* fetchContractDetails(action){
     try{
         const contractDetails = yield axios.get(`/api/contract/${action.payload}`);
         yield put({ type: 'SET_CONTRACT_DETAILS', payload: contractDetails.data});
-        action.checkForUserAction();
+        console.log('before checkForUserAction');
+        action.checkForUserAction(contractDetails.data);
     } catch (error) {
         console.log('Error in fetchContractDetails (saga)', error);
         alert('Something went wrong fetching the selected contract details');


### PR DESCRIPTION
Adding the conditional rendering to ContractDetail and ContractPreview required small changes in several other components. 

In order for certain MUI components to only show if the logged in user needs to do something, I changed the default contract_status to 'pending_second_party_response' in defaultNewContract in contract.reducer.js. Because of that change, I also updated everywhere that contracts were mapped or displayed based on the 'pending' status and changed 'pending' to 'pending_second_party_response', including in: 

- Dashboard
- RecipientView

Because of this contract_status update, no contracts with the status 'pending' will show once this PR is merged. New contracts will show with contract_status: 'pending_second_party_response'.

Added conditionally rendered buttons to ContractDetails. The buttons display if userAction === true. userAction is called in fetchContractDetails in contract.saga.js.

Added conditionally rendered textfield to ContractPreview. The textfield displays if userAction === true. userAction is passed as a prop from ContractDetails to ContractPreview.

User flow was tested and successful. 