### PR TITLE
Updated signature labels from 'your signature'/'second party signature' to 'buyer signature'/'seller signature'

### DIFF
--- a/src/components/ContractPreview/ContractPreview.jsx
+++ b/src/components/ContractPreview/ContractPreview.jsx
@@ -98,13 +98,13 @@ function ContractPreview({contractDetails}) {
 
                         <TableRow>
                             <TableCell sx={{ width: 150 }} align="left">
-                            <Typography>Your Signature:</Typography></TableCell>
+                            <Typography>{contractDetails.first_party_type} Signature:</Typography></TableCell>
                             <TableCell align="left">{contractDetails.first_party_signature}</TableCell>
                         </TableRow>
 
                         <TableRow>
                             <TableCell sx={{ width: 150 }} align="left">
-                            <Typography>Second Party's Signature:</Typography></TableCell>
+                            <Typography>{contractDetails.second_party_type} Signature:</Typography></TableCell>
                             <TableCell align="left">{contractDetails.second_party_signature}</TableCell>
                         </TableRow>
 

--- a/src/components/CreateContract/CreateContractReview.jsx
+++ b/src/components/CreateContract/CreateContractReview.jsx
@@ -91,7 +91,7 @@ const CreateContractReview = () => {
                   <TableCell align="left">{newContractDetails.contract_notes}</TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell sx={{width: 150}} align="left"><Typography>Your Signature:</Typography></TableCell>
+                  <TableCell sx={{width: 150}} align="left"><Typography>{newContractDetails.first_party_type} Signature:</Typography></TableCell>
                   <TableCell align="left">{newContractDetails.first_party_signature}</TableCell>
                 </TableRow>
                 <TableRow>


### PR DESCRIPTION
Updated signature labels from 'your signature'/'second party signature' to 'buyer signature'/'seller signature' in ContractPreview and CreateContractReview Components so each party's role is clear to contract recipient or logged-in user and displays correctly regardless of whether user is buyer or seller. 