### PR TITLE
user can decline contract from ContractDetails

### DIFF
--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -123,8 +123,7 @@ function ContractDetails() {
                           <Box sx={{ display: 'flex', justifyContent: 'center' }}>
                             <Button
                               variant="contained"
-                              // onClick to update contract_status to 'accepted' and add second party signature, trigger PDF generation, and show success alert to user
-                              onClick={(event) => finalizeContract()}
+                              onClick={finalizeContract}
                               sx={{ marginRight: 1, width: 200, height: 60 }}
                             >
                               Sign and Finalize Contract

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -60,6 +60,37 @@ function ContractDetails() {
     history.push('/dashboard');
   }
 
+  // prompts recipient to confirm before contract is declined
+  const confirmDecline = () => {
+    console.log('in confirmDecline');
+    if (window.confirm('Are you sure you want to decline this contract?')) {
+      declineContract();
+    }
+  };
+
+  // dispatches 'UPDATE_CONTRACT_STATUS' with payload of contract object and function handleContractStatusUpdate
+  const declineContract = () => {
+    console.log('in declineContract. Contract id to decline is:', contractDetails.id);
+    dispatch({
+      type: 'UPDATE_CONTRACT_STATUS',
+      payload: {
+        id: contractDetails.id,
+        contract_status: 'declined',
+        contract_approval: false,
+        second_party_signature: null
+      },
+      handleContractStatusUpdate
+    });
+  }
+
+  // passed as part of declineContract, contract by key re-renders in RecipientView with updated status and alerts recipient of successful decline
+  const handleContractStatusUpdate = () => {
+    console.log('in handleContractStatusUpdate');
+    // dispatch({ type: 'FETCH_RECIPIENT_CONTRACT', payload: searchContractKey });
+    alert('Thank you! The contract has been declined.');
+    history.push('/dashboard');
+  }
+
   return (
     <div>
       {/* page heading. May be a better way to handle this but it will be useful for the user to see the contract status in the heading */}
@@ -102,7 +133,7 @@ function ContractDetails() {
                             <Button
                               variant="contained"
                               color="error"
-                              // onClick to update contract_status to 'declined', trigger a declined contract confirmation alert, and return user to /dashboard
+                              onClick={confirmDecline}
                               sx={{ marginLeft: 1, width: 200, height: 60 }}
                             >
                               Decline Contract

--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -86,7 +86,6 @@ function ContractDetails() {
   // passed as part of declineContract, contract by key re-renders in RecipientView with updated status and alerts recipient of successful decline
   const handleContractStatusUpdate = () => {
     console.log('in handleContractStatusUpdate');
-    // dispatch({ type: 'FETCH_RECIPIENT_CONTRACT', payload: searchContractKey });
     alert('Thank you! The contract has been declined.');
     history.push('/dashboard');
   }


### PR DESCRIPTION
The confirmDecline, declineContract, and handleUpdateContractStatus functions in RecipientView were copied into ContractDetails.

confirmDecline is called when the user clicks the 'Decline Contract' button. 

A couple changes were made to handleUpdateContractStatus:
- dispatch line of code removed
- user is routed to /dashboard after they confirm the user alert

User flow was successfully tested. Also confirmed that declining the contract from RecipientView, pre-registration, still works. 