### PR TITLE
ContractPreview: updated hard-coded image, added PDF link if contract_status === accepted

### DIFF
--- a/src/components/ContractPreview/ContractPreview.jsx
+++ b/src/components/ContractPreview/ContractPreview.jsx
@@ -41,7 +41,15 @@ function ContractPreview({contractDetails}) {
                 <TableContainer elevation={10} component={Paper} sx={{ width: 700 }}>
                     <Table>
                         <TableBody>
-
+                        {
+                            contractDetails.contract_status === 'accepted' ? 
+                            <TableRow>
+                                <TableCell sx={{ width: 150 }} align="left">
+                                <Typography>Contract PDF:</Typography></TableCell>
+                                <TableCell align="left"><Typography sx={{textDecoration: 'underline'}}>Contract PDF Link</Typography></TableCell>
+                            </TableRow> :
+                            <></>
+                        }
                         <TableRow>
                             <TableCell sx={{ width: 150 }} align="left">
                             <Typography>Contract Title:</Typography></TableCell>

--- a/src/components/ContractPreview/ContractPreview.jsx
+++ b/src/components/ContractPreview/ContractPreview.jsx
@@ -114,8 +114,8 @@ function ContractPreview({contractDetails}) {
 
                             {/* once image upload is enabled, the img src will be the uploaded image file */}
                             <TableCell align="left">
-                            <img src="https://i.ebayimg.com/images/g/ZUkAAOSw0x1jd7sn/s-l500.jpg"
-                                alt="guitar"
+                            <img src="https://i.ebayimg.com/images/g/l3sAAOSweURjjW1j/s-l500.jpg"
+                                alt="red 2018 Honda Accord"
                                 width="200" /></TableCell>
                         </TableRow>
                         </TableBody>


### PR DESCRIPTION
Updated the hard-coded image in ContractPreview to be a red 2018 Honda Accord to match our demo narrative.

Added a conditionally rendered TableRow that displays 'Contract PDF Link' (in the future it will be the actual PDF link) if contract_status === 'accepted'. 

Tested the conditional rendering. It only shows when contract_status === 'accepted'.