### PR TITLE
contract recipient must enter signature in order to finalize a contract

### DIFF
--- a/src/components/ContractDetails/ContractDetails.jsx
+++ b/src/components/ContractDetails/ContractDetails.jsx
@@ -40,6 +40,10 @@ function ContractDetails() {
   // dispatches 'FINALIZE_CONTRACT' with payload of contract object and the function userAlert
   const finalizeContract = () => {
     console.log('in finalizeContract, second party signature:', secondPartySignature);
+    if (!secondPartySignature) {
+      alert('You must enter your signature in order to finalize this contract.');
+      return;
+    }
     // dispatch to contract saga to update contract details in database
     dispatch({
       type: 'FINALIZE_CONTRACT',


### PR DESCRIPTION
Added conditional to finalizeContract function in ContractDetails that checks to see if secondPartySignature has a value. If it doesn't, the user is alerted that they need to sign in order to finalize the contract.